### PR TITLE
Config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,18 @@ Circa is a project for [Carbon Hack 22](https://taikai.network/en/gsf/hackathons
     </a>
     to check for carbon intensity
   </dd>
-  <dt><b>-l</b> &lt;duration&gt;</dt>
+  <dt><b>-d</b> &lt;duration&gt;</dt>
   <dd>estimated window of runtime of command/task in minutes</dd>
   <dt><b>-u</b> &lt;api url&gt;</dt>
   <dd>url prefix of Carbon Aware API server to consult</dd>
 </dl>
+
+### Configuration
+
+Defaults for the _url_ and _location_ settings can be configured system-wide or
+per user by using a [config file](circa.conf).  This should be placed in
+`/etc/circa.conf` or/and `~/.circa/config`.  These defaults are overridable by
+the command line options above.
 
 ### Example
 

--- a/circa.conf
+++ b/circa.conf
@@ -1,0 +1,12 @@
+# Circa - carbon nice scripting
+
+# This is a config file for the `ca` command that provides some defaults
+# for your local system or for each user.  The command looks for it at
+# `/etc/circa.conf` or `~/.circa/config`.  The format is key value pairs
+# separated by a single space.
+
+# Url to API endpoint, without trailing slash
+url https://carbon-aware-api.azurewebsites.net
+
+# Location to request carbon intensity data for
+location uksouth


### PR DESCRIPTION
This PR allows `ca` to have defaults set in a system config file `/etc/circa.conf` or per-user `$HOME/.circa/config` - or both.

These files are optional, and attempted to be read in order.  In turn, specifying command line options override the configured defaults.

The file is simple key value pairs, separated by a space.  Blank lines and `#` comments are ignored.

```
# Circa config
url https://carbon-aware-api.azurewebsites.net
location australiaeast
```

Fixes #2.

Provides a default for #4.