### PR TITLE
Build on windows using WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,52 @@ per user by using a [config file](circa.conf).  This should be placed in
 `/etc/circa.conf` or/and `~/.circa/config`.  These defaults are overridable by
 the command line options above.
 
-### Example
+## Examples
 
 On macOS, you could run the following to pop up a reminder to charge your latop for a couple of hours:
 
 ```
-./ca -d 120 8 osascript -e 'display notification "Why not plug in your charger?" with title "Low Carbon Energy Available"'
+ca -d 120 8 osascript -e 'display notification "Why not plug in your charger?" with title "Lower Carbon Energy Available"'
 ```
 
+If you install it with WSL under Windows, you can do something similar with this PowerShell script:
+
+```
+function Show-Notification {
+    param (
+        [string] $ToastText1,
+        [string] $ToastText2
+    )
+
+    $Notification = "<toast>
+      <visual>
+        <binding template='ToastText02'>
+          <text id='1'>$($ToastText1)</text>
+          <text id='2'>$($ToastText2)</text>
+        </binding>
+      </visual>
+    </toast>"
+
+    $NotificationXml = New-Object Windows.Data.Xml.Dom.XmlDocument
+    $NotificationXml.LoadXml($Notification)
+
+    $Toast = [Windows.UI.Notifications.ToastNotification]::new($NotificationXml)
+    $Toast.Tag = "Carbon Aware"
+    $Toast.Group = "Carbon Aware"
+    $Toast.ExpirationTime = [DateTimeOffset]::Now.AddMinutes(1)
+
+    $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("Carbon Aware")
+    $Notifier.Show($Toast);
+}
+
+wsl ca -d 120 8
+Show-Notification "Lower Carbon Energy Available" "Why not plug in your charger?"
+```
+
+Save the above in a file (e.g. `carbon-aware.ps1`) and run it from a Windows
+PowerShell prompt.  You may need to run
+`Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass`
+in your PowerShell window first.
 
 ## Motivation
 

--- a/circa.c
+++ b/circa.c
@@ -358,7 +358,7 @@ void parse_response(response_t *response, void *wait_seconds) {
                               .tm_min = m,
                               .tm_sec = s};
     time_t now, optimal_time;
-    optimal_time = timegm(&timestamp_tm); // or _mkgmtime() on windows
+    optimal_time = timegm(&timestamp_tm);
     time(&now);
     *(double *)wait_seconds = difftime(optimal_time, now);
   }


### PR DESCRIPTION
I attempted to install WSL 2 using `wsl --install` in an Administartor Command Prompt although this failed after the reboot as it was running in Parallels, so instead I dropped back to WSL 1 using:
```
wsl --update
wsl --set-default-version 1
wsl --install -d Ubuntu
```

I was then able to build circa using the standard Ubuntu commands from the release tarball.
__

I did briefly look at compiling it natively for Windows, e.g. using CMake, but this seems like a lot of effort when WSL works out of the box.
__

Instead I attempted to use circa in its 'blocking' sleep mode in a PowerShell script - while a lot more verbose than the equivalent macOS version, it does work so I added it to the Examples section.

The PowerShell notification function in the script is based on this (blog post)[https://den.dev/blog/powershell-windows-notification/].
