### PR TITLE
Support calling Carbon Aware SDK CLI directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ Circa is a project for [Carbon Hack 22](https://taikai.network/en/gsf/hackathons
   <dt><b>-d</b> &lt;duration&gt;</dt>
   <dd>estimated window of runtime of command/task in minutes</dd>
   <dt><b>-u</b> &lt;api url&gt;</dt>
-  <dd>url prefix of Carbon Aware API server to consult</dd>
+  <dd>
+    url prefix of Carbon Aware API server to consult OR<br>
+    full path to Carbon Aware CLI executable
+  </dd>
 </dl>
 
 ### Configuration
@@ -173,8 +176,60 @@ make
 ### Building on Ubuntu
 
 ```
-sudo apt-get install -y build-essential libjansson-dev libcurl4-openssl-dev
+sudo apt-get install -y build-essential libcurl4-openssl-dev libjansson-dev
 autoreconf -fi
 ./configure
 make
+```
+
+### Building on Fedora
+
+```
+sudo dnf -y install autoconf automake curl-devel jansson-devel
+autoreconf -fi
+./configure
+make
+```
+
+### Carbon Aware CLI
+
+To install the SDK CLI you will first need the .NET SDK
+
+   * macOS - download and install the (macOS .NET SDK Installer)[https://dotnet.microsoft.com/en-us/download/dotnet/6.0].
+   * Ubuntu - `sudo apt-get install -y dotnet-sdk-6.0`
+   * Fedora - `sudo yum -y install dotnet`
+
+Then you will need the *new* CLI redesign
+(pull request)[https://github.com/Green-Software-Foundation/carbon-aware-sdk/pull/158] branch:
+```
+curl -LO https://github.com/microsoft/carbon-aware-sdk/archive/refs/heads/162/cli-redesign.tar.gz
+tar xf cli-redesign.tar.gz
+cd carbon-aware-sdk-162-cli-redesign/src/CarbonAware.CLI/src
+```
+
+Update the `appsettings.json`, for example, with your WattTime credentials:
+```
+vi appsettings.json 
+{
+    "Logging": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "AllowedHosts": "*",
+    "carbonAwareVars": {
+        "carbonIntensityDataSource": "WattTime"
+    },
+    "wattTimeClient": {
+        "username": "<watttime username>",
+        "password": "<watttime password>"
+    }
+}
+```
+
+Build a release and test it:
+```
+dotnet publish -c Release
+bin/Release/net6.0/publish/caw emissions -l eastus
 ```

--- a/circa.c
+++ b/circa.c
@@ -314,7 +314,7 @@ void call_cli(char *cmd, void (*extract_data)(response_t *, void *),
   FILE *fp;
 
   if ((fp = popen(cmd, "r")) == NULL) {
-    fprintf(stderr, "Error opening pipe!\n");
+    fprintf(stderr, "Error running CLI command\n");
     return;
   }
 
@@ -327,8 +327,6 @@ void call_cli(char *cmd, void (*extract_data)(response_t *, void *),
     fprintf(stderr, "Command not found or exited with error status\n");
     return;
   }
-
-  printf("OUTPUT: %s", response.text);
 
   extract_data(&response, data);
 

--- a/circa.c
+++ b/circa.c
@@ -212,7 +212,8 @@ the program will just block until the best time.\n\n",
   printf("OPTIONS:\n\
   -l <location>     specify location to check for carbon intensity\n\
   -d <duration>     estimated window of runtime of command/task in minutes\n\
-  -u <api url>      url prefix of Carbon Aware API server to consult\n");
+  -u <api url>      url prefix of Carbon Aware API server to consult OR\n\
+                    full path to Carbon Aware CLI executable\n");
 }
 
 void format_params(params_t *params, size_t iso8601_size, char *iso8601_format,
@@ -326,6 +327,8 @@ void call_cli(char *cmd, void (*extract_data)(response_t *, void *),
     fprintf(stderr, "Command not found or exited with error status\n");
     return;
   }
+
+  printf("OUTPUT: %s", response.text);
 
   extract_data(&response, data);
 

--- a/circa.conf
+++ b/circa.conf
@@ -5,8 +5,11 @@
 # `/etc/circa.conf` or `~/.circa/config`.  The format is key value pairs
 # separated by a single space.
 
-# Url to API endpoint, without trailing slash
+# Url to API endpoint, without trailing slash 
 url https://carbon-aware-api.azurewebsites.net
+
+# OR full path to CLI executable
+# url /home/circa/carbon-aware-sdk-162-cli-redesign/src/CarbonAware.CLI/src/bin/Release/net6.0/publish/caw
 
 # Location to request carbon intensity data for
 location uksouth


### PR DESCRIPTION
This PR updates circa to allow it to use the Carbon Aware CLI SDK directly.

This is based on the *new* CLI redesign - see https://github.com/Green-Software-Foundation/carbon-aware-sdk/pull/158 .

**Note that the JSON returned via the CLI is slightly different to that returned via the API.**

Fixes #3